### PR TITLE
add PNG export

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -3,3 +3,24 @@
   font-family: "Virgil";
   src: url("https://uploads.codesandbox.io/uploads/user/ed077012-e728-4a42-8395-cbd299149d62/AflB-FG_Virgil.ttf");
 }
+
+.exportWrapper {
+  margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+}
+.exportWrapper label {
+  display: flex;
+  align-items: center;
+  margin: 0 5px;
+}
+
+.exportWrapper button {
+  margin-right: 10px;
+}
+
+.exportWrapper input[type="number"] {
+  width: 40px;
+  padding: 2px;
+  margin-left: 10px;
+}


### PR DESCRIPTION
Added basic PNG export. Manually tested on Chrome & FF (not sure if Safari works).

Closes https://github.com/vjeux/excalibur/issues/23

Changes:

1. Support export to PNG (Selection is cleared before export. Also allow to clip canvas to visible area only + padding).
2. ensure `Backspace` isn't prevented in input fields.
3. (forgot to remove): added support to setting `width`/`height` to `newElement` factory (useful for testing).

![image](https://user-images.githubusercontent.com/5153846/71671980-ef272e00-2d74-11ea-83e2-ce4a1bceb5e4.png)
